### PR TITLE
Fixed plugin dir path for java

### DIFF
--- a/hooks/after_prepare.js
+++ b/hooks/after_prepare.js
@@ -53,7 +53,7 @@ module.exports = function(context) {
         });
 
         if (platform == 'android') {
-            var pluginDir = path.join(platformPath, 'src');
+            var pluginDir = platformInfo.locations.javaSrc;
             replaceCryptKey_android(pluginDir, encryptedKey, encryptedIv, publicKey);
 
             var cfg = new ConfigParser(platformInfo.projectConfig.path);


### PR DESCRIPTION
I'm quite new to cordova, so not sure how to make this backward compatible. But..looks like java src directory is changed in cordova 8.0.  

I got this exception: 
> UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): Error: ENOENT: no such file or directory, open 'path-to-project/platforms/android/src/com/qhng/cordova/DecryptResourceNG.java'
(node:41796) DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.

Fixed that by updating the plugin directory path. 